### PR TITLE
[HAL][GPIO] Fix documentation errors.

### DIFF
--- a/Inc/stm32l4xx_hal_gpio.h
+++ b/Inc/stm32l4xx_hal_gpio.h
@@ -164,7 +164,7 @@ typedef enum
 /**
   * @brief  Check whether the specified EXTI line flag is set or not.
   * @param  __EXTI_LINE__ specifies the EXTI line flag to check.
-  *         This parameter can be GPIO_PIN_x where x can be(0..15)
+  *         This parameter can be GPIO_PIN_x where x can be (0..15)
   * @retval The new state of __EXTI_LINE__ (SET or RESET).
   */
 #define __HAL_GPIO_EXTI_GET_FLAG(__EXTI_LINE__)       (EXTI->PR1 & (__EXTI_LINE__))
@@ -180,7 +180,7 @@ typedef enum
 /**
   * @brief  Check whether the specified EXTI line is asserted or not.
   * @param  __EXTI_LINE__ specifies the EXTI line to check.
-  *          This parameter can be GPIO_PIN_x where x can be(0..15)
+  *          This parameter can be GPIO_PIN_x where x can be (0..15)
   * @retval The new state of __EXTI_LINE__ (SET or RESET).
   */
 #define __HAL_GPIO_EXTI_GET_IT(__EXTI_LINE__)         (EXTI->PR1 & (__EXTI_LINE__))
@@ -196,7 +196,7 @@ typedef enum
 /**
   * @brief  Generate a Software interrupt on selected EXTI line.
   * @param  __EXTI_LINE__ specifies the EXTI line to check.
-  *          This parameter can be GPIO_PIN_x where x can be(0..15)
+  *          This parameter can be GPIO_PIN_x where x can be (0..15)
   * @retval None
   */
 #define __HAL_GPIO_EXTI_GENERATE_SWIT(__EXTI_LINE__)  (EXTI->SWIER1 |= (__EXTI_LINE__))

--- a/Src/stm32l4xx_hal_gpio.c
+++ b/Src/stm32l4xx_hal_gpio.c
@@ -301,7 +301,7 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
   * @brief  De-initialize the GPIOx peripheral registers to their default reset values.
   * @param  GPIOx where x can be (A..H) to select the GPIO peripheral for STM32L4 family
   * @param  GPIO_Pin specifies the port bit to be written.
-  *         This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15).
   * @retval None
   */
 void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
@@ -387,7 +387,7 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
   * @brief  Read the specified input port pin.
   * @param  GPIOx where x can be (A..H) to select the GPIO peripheral for STM32L4 family
   * @param  GPIO_Pin specifies the port bit to read.
-  *         This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15).
   * @retval The input port pin value.
   */
 GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
@@ -417,7 +417,7 @@ GPIO_PinState HAL_GPIO_ReadPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
   *
   * @param  GPIOx where x can be (A..H) to select the GPIO peripheral for STM32L4 family
   * @param  GPIO_Pin specifies the port bit to be written.
-  *         This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15).
   * @param  PinState specifies the value to be written to the selected bit.
   *         This parameter can be one of the GPIO_PinState enum values:
   *            @arg GPIO_PIN_RESET: to clear the port pin
@@ -468,7 +468,7 @@ void HAL_GPIO_TogglePin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
   *         until the next reset.
   * @param  GPIOx where x can be (A..H) to select the GPIO peripheral for STM32L4 family
   * @param  GPIO_Pin specifies the port bits to be locked.
-  *         This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
+  *         This parameter can be any combination of GPIO_PIN_x where x can be (0..15).
   * @retval None
   */
 HAL_StatusTypeDef HAL_GPIO_LockPin(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)


### PR DESCRIPTION
Hi!

This fixes some trivial typos in GPIO function doxygen comments. Most notably some comments specified that:

```
 This parameter can be any combination of GPIO_Pin_x where x can be (0..15).
```

While the actual macros are:
```
#define GPIO_PIN_0                 ((uint16_t)0x0001)  /* Pin 0 selected    */
#define GPIO_PIN_1                 ((uint16_t)0x0002)  /* Pin 1 selected    */
...
```
This caused some confusion for students in a course I help run.

Please note that this exact typo is found in many places across most other HAL driver repos. Some examples:

- https://github.com/STMicroelectronics/stm32g0xx_hal_driver/blob/48c6ac475eee0a958f611b2e9305fe25b95fc9bc/Src/stm32g0xx_hal_gpio.c#L286
- https://github.com/STMicroelectronics/stm32l4xx_hal_driver/blob/cbc2a703ba03114fe83e1fc1273671081ecd785e/Src/stm32l4xx_hal_gpio.c#L390
- https://github.com/STMicroelectronics/stm32l1xx_hal_driver/blob/36266520b04570310d3dcc343d1c479b2c2bbbae/Src/stm32l1xx_hal_gpio.c#L466
- https://github.com/STMicroelectronics/stm32l0xx_hal_driver/blob/9d7402ea840357d8224592af199a132c3340ee1f/Src/stm32l0xx_hal_gpio.c#L450
- https://github.com/STMicroelectronics/stm32g4xx_hal_driver/blob/7c2e19ec21714f0d993ae5bfe8859a45debcfdd6/Src/stm32g4xx_hal_gpio.c#L452
- https://github.com/STMicroelectronics/stm32f7xx_hal_driver/blob/343e421f8ac1018481aef751e4de913f1080d5b0/Src/stm32f7xx_hal_gpio.c#L367
- https://github.com/STMicroelectronics/stm32f3xx_hal_driver/blob/d2a8fb62d4de6fbad2f575c68386401184e771e0/Src/stm32f3xx_hal_gpio.c#L461
- https://github.com/STMicroelectronics/stm32f1xx_hal_driver/blob/3f810594a401e7b17771e6ad1d7c86bdfbb45cb0/Src/stm32f1xx_hal_gpio.c#L508

....

Thanks!